### PR TITLE
Add react-native-sodium variant to consento/crypto

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,8 +43,8 @@
     "sodium-universal": "^2.0.0"
   },
   "devDependencies": {
-    "@leichtgewicht/pack-ts": "^1.0.0",
     "@consento/sync-randombytes": "^1.0.2",
+    "@leichtgewicht/pack-ts": "^1.0.0",
     "@types/jest": "^24.0.18",
     "@types/libsodium-wrappers-sumo": "^0.7.1",
     "@typescript-eslint/eslint-plugin": "^2.3.2",
@@ -55,6 +55,7 @@
     "eslint-plugin-promise": "^4.2.1",
     "eslint-plugin-standard": "^4.0.1",
     "jest": "^24.9.0",
+    "react-native-sodium": "^0.3.5",
     "rexreplace": "^4.1.1",
     "ts-jest": "^24.1.0",
     "ts-node": "^8.4.1",

--- a/src/core/friends.ts
+++ b/src/core/friends.ts
@@ -9,6 +9,7 @@ import {
 import {
   ICryptoCore, IAnnonymousKeys, IEncryptedMessage, IDecryption, IKeys
 } from './types'
+import { split } from '../util/split'
 
 /* eslint @typescript-eslint/camelcase: "off" */
 const {
@@ -46,14 +47,6 @@ function randomBuffer (size: number): Buffer {
   const buffer = sodium_malloc(size)
   randombytes_buf(buffer)
   return buffer
-}
-
-function split (buffer: Uint8Array, offset: number): Uint8Array[] {
-  const sliced = [
-    buffer.slice(0, offset),
-    buffer.slice(offset)
-  ]
-  return sliced
 }
 
 const deriveContext = Buffer.from('conotify')

--- a/src/core/rnSodium.ts
+++ b/src/core/rnSodium.ts
@@ -1,0 +1,159 @@
+import sodium from 'react-native-sodium'
+import { bufferToString, Buffer, IEncodable, anyToBuffer, bufferToAny } from '../util/buffer'
+import { IAnnonymousKeys, ICryptoCore, IEncryptedMessage, IDecryption, IKeys } from './types'
+import { split } from '../util/split'
+
+async function boxSecretFromSignSecret (signSecretKey: string): Promise<string> {
+  return sodium.crypto_sign_ed25519_sk_to_curve25519(signSecretKey)
+}
+
+async function boxPublicFromSignPublic (signPublicKey: string): Promise<string> {
+  return sodium.crypto_sign_ed25519_pk_to_curve25519(signPublicKey)
+}
+
+async function decrypt (signReadKey: string, signWriteKey: string, messageEncrypted: Uint8Array): Promise<string> {
+  const [ encryptPublicKey, encryptSecretKey ] = await Promise.all([
+    boxPublicFromSignPublic(signReadKey),
+    boxSecretFromSignSecret(signWriteKey)
+  ])
+  return sodium.crypto_box_seal_open(bufferToString(messageEncrypted, 'base64'), encryptPublicKey, encryptSecretKey)
+}
+
+async function encrypt (signPublicKey: string, message: Uint8Array): Promise<Uint8Array> {
+  const encryptPublicKey = await boxPublicFromSignPublic(signPublicKey)
+  return Buffer.from(
+    await sodium.crypto_box_seal(bufferToString(message, 'base64'), encryptPublicKey),
+    'base64'
+  )
+}
+
+async function sign (signSecretKey: Uint8Array, body: Uint8Array): Promise<Uint8Array> {
+  return Buffer.from(
+    await sodium.crypto_sign_detached(
+      bufferToString(body, 'base64'),
+      bufferToString(signSecretKey, 'base64')
+    ),
+    'base64'
+  )
+}
+
+async function verify (signPublicKey: Uint8Array, signature: Uint8Array, body: Uint8Array): Promise<boolean> {
+  return await sodium.crypto_sign_verify_detached(
+    bufferToString(signature, 'base64'),
+    bufferToString(body, 'base64'),
+    bufferToString(signPublicKey, 'base64')
+  ).catch(_ => false)
+}
+
+const deriveContext = 'conotify'
+
+export const rnSodium: ICryptoCore = {
+  async deriveKdfKey (key: Uint8Array) {
+    return Buffer.from(
+      await sodium.crypto_kdf_derive_from_key(1, deriveContext, key),
+      'base64'
+    )
+  },
+  sign,
+  verify,
+  async deriveAnnonymousKeys (readKey: Uint8Array): Promise<IAnnonymousKeys> {
+    const { pk, sk } = await sodium.crypto_sign_seed_keypair(bufferToString(readKey, 'base64'))
+    return {
+      annonymous: true,
+      read: Buffer.from(pk, 'base64'),
+      write: Buffer.from(sk, 'base64')
+    }
+  },
+  async deriveReadKey (writeKey: Uint8Array) {
+    return Buffer.from(
+      await sodium.crypto_sign_ed25519_sk_to_pk(bufferToString(writeKey, 'base64')),
+      'base64'
+    )
+  },
+  async createSecretKey () {
+    return Buffer.from(
+      await sodium.randombytes_buf(sodium.crypto_secretbox_KEYBYTES),
+      'base64'
+    )
+  },
+  async encrypt (secretKey: Uint8Array, body: IEncodable): Promise<Uint8Array> {
+    const message = anyToBuffer(body)
+    const nonce = await sodium.randombytes_buf(sodium.crypto_secretbox_NONCEBYTES)
+    const ciphertext = Buffer.from(await sodium.crypto_secretbox_easy(
+      bufferToString(message, 'base64'),
+      nonce,
+      bufferToString(secretKey, 'base64')
+    ), 'base64')
+    const buffer = Buffer.concat([Buffer.from(nonce, 'base64'), ciphertext])
+    return buffer
+  },
+  async decrypt (secretKey: Uint8Array, encrypted: Uint8Array): Promise<IEncodable> {
+    const [nonce, ciphertext] = split(encrypted, sodium.crypto_secretbox_NONCEBYTES)
+    return Buffer.from(
+      await sodium.crypto_secretbox_open_easy(
+        bufferToString(ciphertext, 'base64'),
+        bufferToString(nonce, 'base64'),
+        bufferToString(secretKey, 'base64')
+      ),
+      'base64'
+    )
+  },
+  async decryptMessage (signReadKey: Uint8Array, signWriteKey: Uint8Array, readKey: Uint8Array, message: IEncryptedMessage): Promise<IDecryption> {
+    if (!(await verify(signReadKey, message.signature, message.body))) {
+      return {
+        error: 'invalid-channel'
+      }
+    }
+    const encryptPublicKey = await boxPublicFromSignPublic(bufferToString(signReadKey, 'base64'))
+    const encryptSecretKey = await boxSecretFromSignSecret(bufferToString(signWriteKey, 'base64'))
+    const decrypted = Buffer.from(await decrypt(encryptPublicKey, encryptSecretKey, message.body), 'base64')
+    if (decrypted === null) {
+      return {
+        error: 'invalid-encryption'
+      }
+    }
+    const [signature, body] = split(decrypted, sodium.crypto_sign_BYTES)
+    if (!(await verify(readKey, signature, body))) {
+      return {
+        error: 'invalid-owner'
+      }
+    }
+    return {
+      body: bufferToAny(body)
+    }
+  },
+  async encryptMessage (annonymousReadKey: Uint8Array, annonymousWriteKey: Uint8Array, writeKey: Uint8Array, message: IEncodable) {
+    const msgBuffer = anyToBuffer(message)
+    const signedStandardized = await sign(writeKey, msgBuffer)
+    const secret = Buffer.concat([signedStandardized, msgBuffer])
+    const encryptPublicKey = await boxPublicFromSignPublic(bufferToString(annonymousReadKey, 'base64'))
+    const body = await encrypt(encryptPublicKey, secret)
+    return {
+      signature: await sign(annonymousWriteKey, body),
+      body
+    }
+  },
+  async initHandshake (): Promise<IKeys> {
+    const { pk, sk } = await sodium.crypto_scalarmult_base()
+    return {
+      write: Buffer.from(sk, 'base64'),
+      read: Buffer.from(pk, 'base64')
+    }
+  },
+  async computeSecret (pri: Uint8Array, remotePublic: Uint8Array): Promise<Uint8Array> {
+    return Buffer.from(
+      await sodium.crypto_scalarmult(
+        bufferToString(pri, 'base64'),
+        bufferToString(remotePublic, 'base64')
+      ),
+      'base64'
+    )
+  },
+  async createKeys (): Promise<IKeys> {
+    const { pk, sk } = await sodium.crypto_sign_keypair()
+    return {
+      read: Buffer.from(pk, 'base64'),
+      write: Buffer.from(sk, 'base64')
+    }
+  }
+}

--- a/src/core/sodium.ts
+++ b/src/core/sodium.ts
@@ -1,4 +1,5 @@
 import _libsodium from '@consento/libsodium-wrappers-sumo'
+import { split } from '../util/split'
 
 import {
   anyToBuffer,
@@ -18,14 +19,6 @@ if (_global.document === null || _global.document === undefined) {
 }
 
 const libsodium = _libsodium.ready.then(() => _libsodium)
-
-function split (buffer: Uint8Array, offset: number): Uint8Array[] {
-  return [
-    buffer.slice(0, offset),
-    buffer.slice(offset)
-  ]
-}
-
 const deriveContext = 'conotify'
 
 /* eslint @typescript-eslint/camelcase: "off" */

--- a/src/types/react-native-sodium.d.ts
+++ b/src/types/react-native-sodium.d.ts
@@ -1,0 +1,58 @@
+declare module 'react-native-sodium' {
+  const sodium: {
+    sodium_version_string (): Promise<string>
+    randombytes_random(): Promise<number>
+    randombytes_uniform(upper_bound: number): Promise<number>
+    randombytes_buf(size: number): Promise<string>
+    randombytes_close(): Promise<0>
+    randombytes_stir(): Promise<0>
+    crypto_secretbox_easy(m: string, n: string, k: string): Promise<string>
+    crypto_secretbox_open_easy(c: string, n: string, k: string): Promise<string>
+    crypto_auth(input: string, k: string): Promise<string>
+    crypto_auth_verify(h: string, input: string, k: string): Promise<number>
+    crypto_box_keypair(): Promise<{pk:string, sk: string}>
+    crypto_box_easy(m: string, n: string, pk: string, sk: string): Promise<string>
+    crypto_box_easy_afternm(m: string, n: string, k: string): Promise<string>
+    crypto_box_open_easy(c: string, n: string, pk: string, sk: string): Promise<string>
+    crypto_box_open_easy_afternm(c: string, n: string, k: string): Promise<string>
+    crypto_box_beforenm(pk: string, sk: string): Promise<string>
+    crypto_pwhash(keylen: number, d: string, t: string, opslimit: number, memlimit: number, algo: number): Promise<string>
+    crypto_box_seal(m: string, pk: string): Promise<string>
+    crypto_box_seal_open(c: string, pk: string, sk: string): Promise<string>
+    crypto_scalarmult_base(n: string): Promise<string>
+    crypto_sign_detached(msg: string, pk: string): Promise<string>
+    crypto_sign_verify_detached(sig: string, msg: string, pk: string): Promise<true> // true or throws!
+    crypto_sign_keypair(): Promise<{pk: string, sk: string}>
+    crypto_sign_seed_keypair(seed: string): Promise<{pk: string, sk: string}>
+    crypto_sign_ed25519_sk_to_seed(sk: string): Promise<string>
+    crypto_sign_ed25519_pk_to_curve25519(pk: String): Promise<string>
+    crypto_sign_ed25519_sk_to_curve25519(sk: string): Promise<string>
+    crypto_sign_ed25519_sk_to_pk (sk: string): Promise<string>
+    crypto_secretbox_KEYBYTES: number
+    crypto_secretbox_NONCEBYTES: number
+    crypto_secretbox_MACBYTES: number
+    crypto_auth_KEYBYTES: number
+    crypto_auth_BYTES: number
+    crypto_box_PUBLICKEYBYTES: number
+    crypto_box_SECRETKEYBYTES: number
+    crypto_box_NONCEBYTES: number
+    crypto_box_MACBYTES: number
+    crypto_box_ZEROBYTES: number
+    crypto_box_SEALBYTES: number
+    crypto_sign_PUBLICKEYBYTES: number
+    crypto_sign_SECRETKEYBYTES: number
+    crypto_sign_SEEDBYTES: number
+    crypto_sign_BYTES: number
+    crypto_pwhash_SALTBYTES: number
+    crypto_pwhash_OPSLIMIT_MODERATE: number
+    crypto_pwhash_OPSLIMIT_MIN: number
+    crypto_pwhash_OPSLIMIT_MAX: number
+    crypto_pwhash_MEMLIMIT_MODERATE: number
+    crypto_pwhash_MEMLIMIT_MIN: number
+    crypto_pwhash_MEMLIMIT_MAX: number
+    crypto_pwhash_ALG_DEFAULT: number
+    crypto_pwhash_ALG_ARGON2I13: number
+    crypto_pwhash_ALG_ARGON2ID13: number
+  }
+  export = sodium
+}

--- a/src/util/split.ts
+++ b/src/util/split.ts
@@ -1,0 +1,6 @@
+export function split (buffer: Uint8Array, offset: number): Uint8Array[] {
+  return [
+    buffer.slice(0, offset),
+    buffer.slice(offset)
+  ]
+}


### PR DESCRIPTION
As the sodium implementation of crypto is very slow, this PR attempts to add [`react-native-sodium`](https://www.npmjs.com/package/react-native-sodium) to see how much slower/faster that is.

Unfortunately react-native-sodium is missing a few functions: https://github.com/lyubo/react-native-sodium/issues/29 