### PR TITLE
Channels & Connections

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -32,6 +32,16 @@ const cryptoFriends = setup(friends) // sodium-universal variant of crypto
 const cryptoSodium = setup(sodium) // libsodium.js variant of crypto
 ```
 
+## Vocabulary
+
+- `Channel` - an e2e encrypted setup consisting of one `Receiver` and one `Sender`
+- `Sender` - an object containing the keys that allow to encrypt data
+- `Receiver` - an object containing the keys that allow to decrypt data created by the `Sender`
+- `Connection` - an e2e encrypted setup consisting of the `Receiver` of one channel and the `Sender` of another.
+- `Annonymous` - an object describing an the capability to verify if a message is part of a `Channel`
+- `Blob` - a self-contained piece of data, like an image or pdf.
+- `Handshake` - the process to connect two separate processes/devices resulting in a `Connection` for each process.
+
 ## Sending/Receiving encrypted messages
 
 The crypto library contains useful primitives for sending e2e encrypted messages through public channels.

--- a/Readme.md
+++ b/Readme.md
@@ -34,87 +34,127 @@ const cryptoSodium = setup(sodium) // libsodium.js variant of crypto
 
 ## Sending/Receiving encrypted messages
 
-The crypto library contains useful primitives for sending e2e encrypted
-messages through public channels:
-
+The crypto library contains useful primitives for sending e2e encrypted messages through public channels.
 
 ```javascript
-const { createReceiver } = setup(sodium)
+const { createChannel } = setup(sodium)
+const { receiver, sender } = createChannel()
+
+const encrypted = sender.encrypt('hello world')
+const decrypted = receiver.decrypt(encrypted)
+
+decrypted.body === 'hello world'
 ```
 
-You can create a new communication channel by creating a new receiver:
+You can create a new communication channel with the simple `createChannel` method.
 
 ```javascript
-const receiver = await createReceiver()
+const channel = await createChannel()
+const { receiver } = channel // Can decrypt messages; _could_ encrypt messages, but these would not be signed and rejected!
+const { sender } = channel // Can only encrypt messages.
+const { annonymous } = channel // Object that can verify messages but not de-/encrypt messages.
+
+receiver.receiveKey // To backup/restore the receiver
+sender.sendKey // To backup/restore the sender
+annonymous.idBase64 === receiver.idBase64 === sender.idBase64 // The lookup id is same here
+
+sender.encryptKey === receiver.encryptKey // Key to encrypt messages
+
+receiver.decryptKey // Allows the receiver to decrypt messages
+sender.signKey // Allows the sender to sign messages
+
 receiver.receiveKey // allows decryption of messages
-receiver.sender.sendKey // encryption key for sending messages
-receiver.sender.annonymous.id // public channel id - can be shared with other people - also used to verify if a message was properly sent.
-receiver.sender.id // shortcut on the sender for the channel id
-receiver.id // shortcut on the receiver for the channel id
+receiver.annonymous.id // public channel id - can be shared with other people - also used to verify if a message was properly sent.
+receiver.id // shortcut on the sender for the channel id
 ```
 
-### Permission layers
-
-A `Receiver` &gt; `Sender` &gt; `Annonymous` and there are methods to create a receiver/annonymous
-instance out of a sender instance:
+All objects create with `createChannel` are well de-/serializable:
 
 ```javascript
-const { createReceiver } = setup(sodium)
-const receiver = await createReceiver()
+const { createChannel, Receiver, Sender, Annonymous } = setup(sodium)
+const { receiver, sender, annonymous } = await createChannel()
+
+new Receiver(receiver.toJSON())
+new Sender(sender.toJSON())
+new Annonymous(annonymous.toJSON())
 ```
 
-you can also destruct each instance:
+### .annonymous
+
+Both the `.sender` and the `.receiver` object have a `.annoymous` field
+to retreive an annonymous instance for the sender/receiver.
 
 ```javascript
-const { receiver, sender, annonymous } = await createReceiver()
+const { receiver, sender } = await createChannel()
+receiver.annonymous.idBase64 === sender.annonymous.idBase64
 ```
 
-Every instance can verify a given message for a channel:
+#### sender.encrypt(body)
+
+Encrypt and sign a given input with the sender key.
+
+- `body` - what you like to encrypt, any serializable object is possible
 
 ```javascript
-const bool = await annonymous.verify(signature: Uint8Array, body: Uint8Array)
-const bool2 = await annonymous.verifyMessage(message: IEncryptedMessage)
+const encrypted = await sender.encrypt('secret message')
+encrypted.signature // Uint8Array
+encrypted.body // Uint8Array
 ```
 
-Only receivers and senders can decrypt a message:
+#### sender.encryptOnly(body)
+
+Only encrypt the body. This is only recommended in an environment where the
+signature needs to be created at a different time!
+
+- `body` - what you like to encrypt, any serializable object is possible
 
 ```javascript
-const message = await receiver.decrypt(message: IEncryptedMessage)
+const encrypted = await sender.encrypt('secret message')
+encrypted // Uint8Array with an encrypted message
 ```
 
-since signing is not the same as encrypting, it is also possible to sign messages for receivers.
+#### sender.sign(data)
+
+Signs a given data. This is only recommended in an environment where the
+data was encrypted at a different time!
+
+- `data` - Uint8Array for which a signature is wanted
 
 ```javascript
-const signature = await receiver.sign(message: Uint8Array)
+const signature = await sender.sign((await sender.encrypt('secret message')).body)
+signature // Uint8Array with the signature of the encrypted message
 ```
 
-but only senders are able to encrypt messages.
+#### annonymous.verify(signature, body)
+
+Using the annonymous object we can verify a given data.
+
+- `signature` - `Uint8Array` with the signature for the `body`
+- `body` - `Uint8Array` with of the encrypted data.
 
 ```javascript
-const encrypted: IEncryptedMessage = await sender.encrypt(message)
+const encrypted = await sender.encrypt('hello world')
+const bool = await annonymous.verify(encrypted.signature, encrypted.body)
 ```
 
-you can also encrypt a message without signing.
+#### annonymous.verifyMessage(message)
+
+As a short-cut its also possible to just verify a message
+
+- `message` - `{ signature: Uint8Array, body: Uint8Array }`
 
 ```javascript
-const encrypted: Uint8Array = await sender.encryptOnly(message)
+const bool = await annonymous.verifyMessage(message)
 ```
 
-and decrypt this message:
+#### receiver.decrypt(encrypted)
+
+Get the content of a once encrypted message.
+
+- `encrypted` - `{ signature: Uint8Array, body: Uint8Array }` as created by `sender.encrypt` or `Uint8Array` created with `sender.encryptOnly`
 
 ```javascript
-const message = await sender.decrypt(uint8Array)
-```
-
-### De-/Serialization
-
-The default created Sender/Receiver/Annonymous instances can be serialized/deserialized
-using common JSON structs:
-
-```javascript
-const { Receiver } = setup(sodium)
-const receiverJson = receiver.toJSON()
-const restoredReceiver = new Receiver(json)
+const message = await receiver.decrypt(message:)
 ```
 
 ## Creating a handshake

--- a/src/handshake/index.ts
+++ b/src/handshake/index.ts
@@ -22,7 +22,7 @@ function processHandshake (msg: Uint8Array): {
   }
 }
 
-export function setupHandshake (crypto: ICryptoCore, { createReceiver, Sender, Receiver, Connection }: ICryptoPrimitives): ICryptoHandshake {
+export function setupHandshake (crypto: ICryptoCore, { createChannel, Sender, Receiver, Connection }: ICryptoPrimitives): ICryptoHandshake {
   class HandshakeInit implements IHandshakeInit {
     receiver: IReceiver
     firstMessage: Uint8Array
@@ -46,7 +46,7 @@ export function setupHandshake (crypto: ICryptoCore, { createReceiver, Sender, R
       return await wrapTimeout(async signal => {
         const cp = checkpoint(signal)
         const secretKey = await cp(crypto.computeSecret(this.handshakeSecret, Buffer.from(accept.token, 'base64')))
-        const bob = await cp(createReceiver())
+        const bob = await cp(createChannel())
         const sendKey = await cp(crypto.decrypt(secretKey, Buffer.from(accept.secret, 'base64')))
         if (!(sendKey instanceof Uint8Array)) {
           throw Object.assign(new Error(`Expected buffer in decrypted message, got: ${sendKey.constructor.name}`), { code: 'invalid-message', sendKey })
@@ -111,7 +111,7 @@ export function setupHandshake (crypto: ICryptoCore, { createReceiver, Sender, R
     async initHandshake (opts?: ITimeoutOptions): Promise<HandshakeInit> {
       return await wrapTimeout(async signal => {
         const cp = checkpoint(signal)
-        const { receiver, sender } = await cp(createReceiver())
+        const { receiver, sender } = await cp(createChannel())
         const { privateKey: handshakeSecret, publicKey: handshakePublic } = await cp(crypto.initHandshake())
         return new HandshakeInit({
           receiver,
@@ -133,7 +133,7 @@ export function setupHandshake (crypto: ICryptoCore, { createReceiver, Sender, R
         const cp = checkpoint(signal)
         const { privateKey: handshakeSecret, publicKey: handshakePublic } = await cp(crypto.initHandshake())
         const secretKey = await cp(crypto.computeSecret(handshakeSecret, token))
-        const { receiver, sender } = await cp(createReceiver())
+        const { receiver, sender } = await cp(createChannel())
         return new HandshakeAccept({
           sender: { sendKey },
           receiver,

--- a/src/primitives/__tests__/index.test.ts
+++ b/src/primitives/__tests__/index.test.ts
@@ -7,26 +7,25 @@ for (const { name, crypto } of cores) {
   const variant = setupPrimitives(crypto)
   describe(`${name}: Permission and encryption for channels`, () => {
     const {
-      createReceiver,
+      createChannel,
       Sender, Receiver, Annonymous
     } = variant
 
     it('a new receiver knows all the secrets', async () => {
-      const receiver = await createReceiver()
-      const { sender, annonymous } = receiver
+      const { receiver, sender, annonymous } = await createChannel()
       expect(receiver.id.length).toBe(32)
       expect(receiver.idBase64).toBeDefined() // called twice for cache test!
       expect(receiver.idBase64).toBe(bufferToString(annonymous.id, 'base64'))
       expect(receiver.idHex).toBeDefined() // called twice for cache test!
       expect(receiver.idHex).toBe(bufferToString(annonymous.id, 'hex'))
       expect(receiver.receiveKey).toBeDefined()
-      expect(receiver.receiveKey.length).toBe(160)
+      expect(receiver.receiveKey.length).toBe(96)
       expect(sender.sendKey).toBeDefined()
       expect(sender.sendKey.length).toBe(128)
     })
 
     it('restoring a partial channel from a base64 string', async () => {
-      const { annonymous: { id } } = await createReceiver()
+      const { annonymous: { id } } = await createChannel()
       const idBase64 = bufferToString(id, 'base64')
       const annonymous = new Annonymous({ id: idBase64 })
       expect(bufferToString(annonymous.id, 'base64')).toBe(idBase64)
@@ -34,13 +33,13 @@ for (const { name, crypto } of cores) {
     })
 
     it('two channels have different ids', async () => {
-      const a = await createReceiver()
-      const b = await createReceiver()
+      const { receiver: a } = await createChannel()
+      const { receiver: b } = await createChannel()
       expect(bufferToString(a.receiveKey, 'base64')).not.toBe(bufferToString(b.receiveKey, 'base64'))
     })
 
     it('a sender can be restored from its toJSON representation', async () => {
-      const { sender: original } = await createReceiver()
+      const { sender: original } = await createChannel()
       const json = original.toJSON()
       if (!('sendKey' in json)) {
         throw new Error('Missing sendKey')
@@ -55,43 +54,41 @@ for (const { name, crypto } of cores) {
     })
 
     it('a sender can be restored from its sendKey only', async () => {
-      const original = await (await createReceiver()).sender
+      const { sender: original } = await createChannel()
       const recovered = await new Sender({ sendKey: original.sendKey })
       expect(bufferToString(recovered.sendKey)).toBe(bufferToString(original.sendKey))
       expect(recovered.idHex).toBe(original.idHex)
     })
 
     it('a receiver can be restored from its toJSON representation', async () => {
-      const original = await createReceiver()
+      const { receiver: original, sender } = await createChannel()
       const json = original.toJSON()
       expect(Object.keys(json)).toEqual(['receiveKey'])
       expect(typeof json.receiveKey).toBe('string')
       const recovered = new Receiver(json)
       expect(bufferToString(recovered.receiveKey)).toBe(bufferToString(original.receiveKey))
       expect(recovered.receiveKeyBase64).toBe(original.receiveKeyBase64)
-      expect(recovered.sender.idBase64).toBe(original.sender.idBase64)
       expect(recovered.idBase64).toBe(original.idBase64)
       const recoveredId = Buffer.from(recovered.idBase64, 'base64')
       expect(recoveredId.length).toBe(32)
       expect(bufferCompare(recoveredId, original.id)).toBe(0)
       const message = Buffer.from('Hello World')
-      const recoveredSender = new Sender(recovered.sender.toJSON())
-      const recoveredAnnonymous = new Annonymous(recoveredSender.annonymous.toJSON())
-      expect(await recoveredAnnonymous.verify(await original.sender.sign(message), message)).toBe(true)
-      expect(await original.sender.annonymous.verify(await recoveredSender.sign(message), message)).toBe(true)
-      expect(await recovered.receiver.decrypt(await recoveredSender.encrypt('hi!'))).toEqual({ body: 'hi!' })
-      expect(await original.receiver.decrypt(await original.sender.encrypt('hi!'))).toEqual({ body: 'hi!' })
+      const recoveredAnnonymous = new Annonymous(recovered.annonymous.toJSON())
+      expect(await recoveredAnnonymous.verify(await sender.sign(message), message)).toBe(true)
+      expect(await recovered.annonymous.verify(await sender.sign(message), message)).toBe(true)
+      expect(await recovered.decrypt(await sender.encrypt('hi!'))).toEqual({ body: 'hi!' })
+      expect(await original.decrypt(await sender.encrypt('hi!'))).toEqual({ body: 'hi!' })
     })
 
     it('a receiver can be restored from its receiveKey only', async () => {
-      const original = await createReceiver()
+      const { receiver: original, sender } = await createChannel()
       const recovered = new Receiver({ receiveKey: original.receiveKey })
       expect(bufferToString(recovered.receiveKey)).toBe(bufferToString(original.receiveKey))
-      expect(recovered.sender.sendKeyBase64).toBe(original.sender.sendKeyBase64)
+      expect(sender.sendKeyBase64).toBe(sender.sendKeyBase64)
     })
 
     it('a annonymous can be restored from its toJSON representation', async () => {
-      const { annonymous: original } = await createReceiver()
+      const { annonymous: original } = await createChannel()
       const json = original.toJSON()
       if (!('id' in json)) {
         throw new Error('Missing id property')
@@ -103,7 +100,7 @@ for (const { name, crypto } of cores) {
     })
 
     it('signing and verifying a message', async () => {
-      const { sender, annonymous } = await createReceiver()
+      const { sender, annonymous } = await createChannel()
       const body = Buffer.from('abcd')
       const signature = await sender.sign(body)
       expect(await annonymous.verify(signature, body)).toBe(true)
@@ -111,8 +108,8 @@ for (const { name, crypto } of cores) {
     })
 
     it('signing and verifying a wrong message', async () => {
-      const { sender } = await createReceiver()
-      const { annonymous } = await createReceiver()
+      const { sender } = await createChannel()
+      const { annonymous } = await createChannel()
       const body = Buffer.from('abcd')
       const signature = await sender.sign(body)
       expect(await annonymous.verify(signature, body)).toBe(false)
@@ -120,21 +117,21 @@ for (const { name, crypto } of cores) {
     })
 
     it('signing and verifying with a partial channel', async () => {
-      const { sender, annonymous } = await createReceiver()
+      const { sender, annonymous } = await createChannel()
       const body = Buffer.from('abcd')
       const signature = await sender.sign(body)
       expect(await annonymous.verify(signature, body)).toBe(true)
     })
 
     it('receiver can decrypt data from sender', async () => {
-      const receiver = await createReceiver()
+      const { receiver, sender } = await createChannel()
       const original = 'Hello World'
-      const message = await receiver.sender.encrypt(original)
+      const message = await sender.encrypt(original)
       expect(await receiver.decrypt(message)).toEqual({ body: original })
     })
 
     it('multiple encryptions return different encryptions', async () => {
-      const { sender } = await createReceiver()
+      const { sender } = await createChannel()
       const message = 'Hello World'
       expect(
         bufferToString((await sender.encrypt(message)).body, 'base64')
@@ -145,19 +142,19 @@ for (const { name, crypto } of cores) {
     })
 
     it('sender as string', async () => {
-      const { sender } = await createReceiver()
+      const { sender } = await createChannel()
       // eslint-disable-next-line @typescript-eslint/no-base-to-string
       expect(sender.toString()).toBe(`Sender[sendKey=${bufferToString(sender.sendKey, 'base64')}]`)
     })
 
     it('receiver as string', async () => {
-      const receiver = await createReceiver()
+      const { receiver } = await createChannel()
       // eslint-disable-next-line @typescript-eslint/no-base-to-string
       expect(receiver.toString()).toBe(`Receiver[receiveKey=${bufferToString(receiver.receiveKey, 'base64')}]`)
     })
 
     it('annonymous as string', async () => {
-      const { annonymous } = await createReceiver()
+      const { annonymous } = await createChannel()
       // eslint-disable-next-line @typescript-eslint/no-base-to-string
       expect(annonymous.toString()).toBe(`Annonymous[id=${annonymous.idBase64}]`)
     })

--- a/src/primitives/index.ts
+++ b/src/primitives/index.ts
@@ -5,43 +5,52 @@ import {
   ISender, ISenderOptions,
   ICryptoPrimitives,
   IConnectionOptions,
-  IConnectionJSON,
+  IConnection,
   ISenderJSON,
-  IReceiverJSON
+  IReceiverJSON,
+  IChannel,
+  IChannelJSON,
+  IConnectionJSON,
+  IChannelOptions
 } from '../types'
 import { Buffer, IEncodable, ITimeoutOptions } from '../util/types'
-import { bufferToString, toBuffer, wrapTimeout, bubbleAbort } from '../util'
+import { bufferToString, toBuffer, wrapTimeout, bubbleAbort, bufferEquals } from '../util'
+
+// Structure of keys:
+//
+// RECEIVE_KEY = [ENCRYPT_KEY][VERIFY_KEY][DECRYPT_KEY]
+// SEND_KEY = [ENCRYPT_KEY][VERIFY_KEY][SIGN_KEY]
+
+const ENCRYPT_KEY_SIZE = 32
+const ENCRYPT_KEY_START = 0
+const ENCRYPT_KEY_END = ENCRYPT_KEY_START + ENCRYPT_KEY_SIZE
+
+const VERIFY_KEY_SIZE = 32
+const VERIFY_KEY_START = ENCRYPT_KEY_END
+const VERIFY_KEY_END = VERIFY_KEY_START + VERIFY_KEY_SIZE
 
 const DECRYPT_KEY_SIZE = 32
-const DECRYPT_KEY_START = 0
+const DECRYPT_KEY_START = VERIFY_KEY_END
 const DECRYPT_KEY_END = DECRYPT_KEY_START + DECRYPT_KEY_SIZE
 
 const SIGN_KEY_SIZE = 64
-const SIGN_KEY_START = 0
+const SIGN_KEY_START = VERIFY_KEY_END
 const SIGN_KEY_END = SIGN_KEY_START + SIGN_KEY_SIZE
 
-const ENCRYPT_KEY_SIZE = 32
-const ENCRYPT_KEY_START = SIGN_KEY_END
-const ENCRYPT_KEY_END = ENCRYPT_KEY_START + ENCRYPT_KEY_SIZE
+function encryptKeyFromSendOrReceiveKey (sendOrReceiveKey: Uint8Array): Uint8Array {
+  return sendOrReceiveKey.slice(ENCRYPT_KEY_START, ENCRYPT_KEY_END)
+}
+
+function verifyKeyFromSendOrReceiveKey (sendOrReceiveKey: Uint8Array): Uint8Array {
+  return sendOrReceiveKey.slice(VERIFY_KEY_START, VERIFY_KEY_END)
+}
 
 function decryptKeyFromReceiveKey (receiveKey: Uint8Array): Uint8Array {
   return receiveKey.slice(DECRYPT_KEY_START, DECRYPT_KEY_END)
 }
 
-function sendKeyFromReceiveKey (receiveKey: Uint8Array): Uint8Array {
-  return receiveKey.slice(DECRYPT_KEY_END)
-}
-
 function signKeyFromSendKey (sendKey: Uint8Array): Uint8Array {
   return sendKey.slice(SIGN_KEY_START, SIGN_KEY_END)
-}
-
-function encryptKeyFromSendKey (sendKey: Uint8Array): Uint8Array {
-  return sendKey.slice(ENCRYPT_KEY_START, ENCRYPT_KEY_END)
-}
-
-function verifyKeyFromSendKey (sendKey: Uint8Array): Uint8Array {
-  return sendKey.slice(ENCRYPT_KEY_END)
 }
 
 export function setupPrimitives (crypto: ICryptoCore): ICryptoPrimitives {
@@ -123,7 +132,7 @@ export function setupPrimitives (crypto: ICryptoCore): ICryptoPrimitives {
 
     get encryptKey (): Uint8Array {
       if (this._encryptKey === undefined) {
-        this._encryptKey = encryptKeyFromSendKey(this.sendKey)
+        this._encryptKey = encryptKeyFromSendOrReceiveKey(this.sendKey)
       }
       return this._encryptKey
     }
@@ -142,10 +151,6 @@ export function setupPrimitives (crypto: ICryptoCore): ICryptoPrimitives {
       return this._sendKeyBase64
     }
 
-    get sender (): this {
-      return this
-    }
-
     get id (): Uint8Array {
       return this.annonymous.id
     }
@@ -160,7 +165,7 @@ export function setupPrimitives (crypto: ICryptoCore): ICryptoPrimitives {
 
     get annonymous (): IAnnonymous {
       if (this._annonymous === undefined) {
-        this._annonymous = new Annonymous({ id: verifyKeyFromSendKey(this.sendKey) })
+        this._annonymous = new Annonymous({ id: verifyKeyFromSendOrReceiveKey(this.sendKey) })
       }
       return this._annonymous
     }
@@ -189,8 +194,9 @@ export function setupPrimitives (crypto: ICryptoCore): ICryptoPrimitives {
   class Receiver implements IReceiver {
     _receiveKey?: Uint8Array
     _receiveKeyBase64?: string
-    _sender?: ISender
     _decryptKey?: Uint8Array
+    _encryptKey?: Uint8Array
+    _annonymous?: IAnnonymous
 
     constructor ({ receiveKey }: IReceiverOptions) {
       if (typeof receiveKey === 'string') {
@@ -200,31 +206,30 @@ export function setupPrimitives (crypto: ICryptoCore): ICryptoPrimitives {
       }
     }
 
-    get sender (): ISender {
-      if (this._sender === undefined) {
-        this._sender = new Sender({ sendKey: sendKeyFromReceiveKey(this.receiveKey) })
-      }
-      return this._sender
-    }
-
     get id (): Uint8Array {
-      return this.sender.id
+      return this.annonymous.id
     }
 
     get idHex (): string {
-      return this.sender.idHex
+      return this.annonymous.idHex
     }
 
     get idBase64 (): string {
-      return this.sender.idBase64
+      return this.annonymous.idBase64
     }
 
-    get receiver (): this {
-      return this
+    get encryptKey (): Uint8Array {
+      if (this._encryptKey === undefined) {
+        this._encryptKey = encryptKeyFromSendOrReceiveKey(this.receiveKey)
+      }
+      return this._encryptKey
     }
 
     get annonymous (): IAnnonymous {
-      return this.sender.annonymous
+      if (this._annonymous === undefined) {
+        this._annonymous = new Annonymous({ id: verifyKeyFromSendOrReceiveKey(this.receiveKey) })
+      }
+      return this._annonymous
     }
 
     get decryptKey (): Uint8Array {
@@ -259,46 +264,85 @@ export function setupPrimitives (crypto: ICryptoCore): ICryptoPrimitives {
     async decrypt (encrypted: IEncryptedMessage): Promise<IDecryption> {
       return await crypto.decryptMessage(
         this.annonymous.id,
-        this.sender.encryptKey,
+        this.encryptKey,
         this.decryptKey,
         encrypted
       )
     }
   }
 
-  class Connection {
+  class Channel implements IChannel {
     receiver: IReceiver
     sender: ISender
+    type: 'channel' = 'channel'
+
+    constructor (opts: IChannelOptions) {
+      this.receiver = (opts.receiver instanceof Receiver) ? opts.receiver : new Receiver(opts.receiver)
+      this.sender = (opts.sender instanceof Sender) ? opts.sender : new Sender(opts.sender)
+      if (opts.type !== undefined && opts.type as string !== 'channel') {
+        throw new Error(`Can not restore a channel from a [${opts.type}]`)
+      }
+      if (!bufferEquals(this.receiver.id, this.sender.id)) {
+        throw new Error('Can not create a channel with both the sender and the receiver have a different id! Did you mean to restore a connection?')
+      }
+    }
+
+    get annonymous (): IAnnonymous {
+      return this.receiver.annonymous
+    }
+
+    toJSON (): IChannelJSON {
+      return {
+        receiver: this.receiver.toJSON(),
+        sender: this.sender.toJSON(),
+        type: 'channel'
+      }
+    }
+  }
+
+  class Connection implements IConnection {
+    receiver: IReceiver
+    sender: ISender
+    type: 'connection' = 'connection'
 
     constructor (opts: IConnectionOptions) {
       this.receiver = (opts.receiver instanceof Receiver) ? opts.receiver : new Receiver(opts.receiver)
       this.sender = (opts.sender instanceof Sender) ? opts.sender : new Sender(opts.sender)
+      if (opts.type !== undefined && opts.type as string !== 'connection') {
+        throw new Error(`Can not restore a connection from a [${opts.type}]`)
+      }
+      if (bufferEquals(this.receiver.id, this.sender.id)) {
+        throw new Error('Can not create a connection with both the sender and the receiver have the same id! Did you mean to restore a channel?')
+      }
     }
 
     toJSON (): IConnectionJSON {
       return {
         receiver: this.receiver.toJSON(),
-        sender: this.sender.toJSON()
+        sender: this.sender.toJSON(),
+        type: 'connection'
       }
     }
   }
+
   return {
-    async createReceiver (opts?: ITimeoutOptions): Promise<IReceiver> {
+    async createChannel (opts?: ITimeoutOptions): Promise<Channel> {
       return await wrapTimeout(async signal => {
         const [encrypt, sign] = await Promise.all([
           crypto.createEncryptionKeys(),
           crypto.createSignKeys()
         ])
         bubbleAbort(signal)
-        const receiver = new Receiver({
-          receiveKey: Buffer.concat([encrypt.privateKey, sign.privateKey, encrypt.publicKey, sign.publicKey])
+        return new Channel({
+          receiver: { receiveKey: Buffer.concat([encrypt.publicKey, sign.publicKey, encrypt.privateKey]) },
+          sender: { sendKey: Buffer.concat([encrypt.publicKey, sign.publicKey, sign.privateKey]) }
         })
-        return receiver
       }, opts)
     },
     Annonymous,
     Receiver,
     Sender,
-    Connection
+    Connection,
+    Channel
   }
 }

--- a/src/util/buffer.ts
+++ b/src/util/buffer.ts
@@ -57,6 +57,10 @@ export function bufferCompare (a: Uint8Array, b: Uint8Array): number {
   return 0
 }
 
+export function bufferEquals (a: Uint8Array, b: Uint8Array): boolean {
+  return bufferCompare(a, b) === 0
+}
+
 export function bufferToString (buffer: Uint8Array, encoding: EEncoding = 'utf8'): string {
   return Buffer.from(buffer).toString(encoding)
 }


### PR DESCRIPTION
Following a conversation with @RangerMauve and upon revisiting the code I noticed that it is better/safer to separate `Sender` and `Receiver`. This required a change of some of the naming. Most relevantly the new method is called `createChannel` instead of `createReceiver`.

To document the structure change better I also differentiated between `Channel` (a Sender/Receiver pair, where the sender can send and the receiver receive) and a `Connection` (a sender/receiver pair to communicate with another sender/receiver pair). 

It is probably obvious that this is a breaking change resulting in crypto 0.5.0

_Review request: Please look if you can find something odd here._